### PR TITLE
fix(concurrency): concurrency::locker header was still present.

### DIFF
--- a/inc/com/centreon/concurrency/thread_posix.hh
+++ b/inc/com/centreon/concurrency/thread_posix.hh
@@ -19,9 +19,9 @@
 #ifndef CC_CONCURRENCY_THREAD_POSIX_HH
 #define CC_CONCURRENCY_THREAD_POSIX_HH
 
+#include <mutex>
 #include <pthread.h>
 #include "com/centreon/namespace.hh"
-#include "com/centreon/concurrency/mutex_posix.hh"
 
 CC_BEGIN()
 
@@ -58,7 +58,7 @@ class thread {
   static void* _execute(void* data);
 
   bool _initialized;
-  mutable mutex _mtx;
+  mutable std::mutex _mtx;
   pthread_t _th;
 };
 }

--- a/src/concurrency/thread_posix.cc
+++ b/src/concurrency/thread_posix.cc
@@ -28,7 +28,6 @@
 #include <sys/time.h>
 #endif  // BSD flavor.
 #include "com/centreon/exceptions/basic.hh"
-#include "com/centreon/concurrency/locker.hh"
 #include "com/centreon/concurrency/thread_posix.hh"
 
 using namespace com::centreon::concurrency;
@@ -53,7 +52,7 @@ thread::~thread() throw() {}
  *  Execute the running method in the new thread.
  */
 void thread::exec() {
-  locker lock(&_mtx);
+  std::lock_guard<std::mutex> lock(_mtx);
   if (_initialized)
     throw(basic_error() << "execute thread failed: already running");
   int ret(pthread_create(&_th, NULL, &_execute, this));
@@ -133,7 +132,7 @@ void thread::usleep(unsigned long usecs) {
  *  Wait the end of the thread.
  */
 void thread::wait() {
-  locker lock(&_mtx);
+  std::lock_guard<std::mutex> lock(_mtx);
 
   // Wait the end of the thread.
   if (_initialized) {
@@ -154,7 +153,7 @@ void thread::wait() {
  *  @return true if the thread end before timeout, otherwise false.
  */
 bool thread::wait(unsigned long timeout) {
-  locker lock(&_mtx);
+  std::lock_guard<std::mutex> lock(_mtx);
   if (_initialized) {
 #if defined(__NetBSD__) || defined(__OpenBSD__)
     // Implementation based on pthread_kill and usleep.

--- a/src/logging/backend.cc
+++ b/src/logging/backend.cc
@@ -24,7 +24,6 @@
 #endif  // _WIN32
 
 #include <cstring>
-#include "com/centreon/concurrency/locker.hh"
 #include "com/centreon/concurrency/thread.hh"
 #include "com/centreon/logging/backend.hh"
 #include "com/centreon/misc/stringifier.hh"

--- a/src/logging/file.cc
+++ b/src/logging/file.cc
@@ -19,7 +19,6 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
-#include "com/centreon/concurrency/locker.hh"
 #include "com/centreon/exceptions/basic.hh"
 #include "com/centreon/logging/file.hh"
 #include "com/centreon/misc/stringifier.hh"

--- a/src/logging/syslogger.cc
+++ b/src/logging/syslogger.cc
@@ -18,7 +18,6 @@
 
 #include <cstdlib>
 #include <syslog.h>
-#include "com/centreon/concurrency/locker.hh"
 #include "com/centreon/exceptions/basic.hh"
 #include "com/centreon/logging/syslogger.hh"
 #include "com/centreon/misc/stringifier.hh"

--- a/test/concurrency/thread_test.hh
+++ b/test/concurrency/thread_test.hh
@@ -19,8 +19,6 @@
 #ifndef CC_TEST_CONCURRENCY_THREAD_TEST_HH
 #define CC_TEST_CONCURRENCY_THREAD_TEST_HH
 
-#include "com/centreon/concurrency/locker.hh"
-
 CC_BEGIN()
 
 namespace concurrency {

--- a/test/logging/backend_test.hh
+++ b/test/logging/backend_test.hh
@@ -19,7 +19,6 @@
 #ifndef CC_TEST_LOGGING_BACKEND_TEST_HH
 #define CC_TEST_LOGGING_BACKEND_TEST_HH
 
-#include "com/centreon/concurrency/locker.hh"
 #include "com/centreon/logging/backend.hh"
 
 CC_BEGIN()


### PR DESCRIPTION
Clib should compile again.