### PR TITLE
Cmake cxx11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 cmake_minimum_required(VERSION 2.8)
 project("Centreon Clib" C CXX)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-add_definitions("-D_GLIBCXX_USE_CXX11_ABI=0")
+add_definitions("-D_GLIBCXX_USE_CXX11_ABI=1")
 
 # Set directories.
 set(INCLUDE_DIR "${PROJECT_SOURCE_DIR}/inc")

--- a/cmake.sh
+++ b/cmake.sh
@@ -17,7 +17,8 @@ if [ -r /etc/centos-release ] ; then
     if rpm -q cmake3 ; then
       cmake='cmake3'
     elif [ $maj = "centos7" ] ; then
-      yum -y install epel-release cmake3
+      yum -y install epel-release
+      yum -y install cmake3
       cmake='cmake3'
     else
       dnf -y install cmake

--- a/cmake.sh
+++ b/cmake.sh
@@ -19,6 +19,9 @@ if [ -r /etc/centos-release ] ; then
     elif [ $maj = "centos7" ] ; then
       yum -y install epel-release cmake3
       cmake='cmake3'
+    else
+      dnf -y install cmake
+      cmake='cmake'
     fi
   fi
 

--- a/cmake.sh
+++ b/cmake.sh
@@ -1,5 +1,81 @@
 #!/bin/bash
 
+if [ "$1" = "-f" ] ; then
+  force=1
+  shift
+fi
+
+# Am I root?
+my_id=$(id -u)
+
+if [ -r /etc/centos-release ] ; then
+  maj="centos$(cat /etc/centos-release | awk '{print $4}' | cut -f1 -d'.')"
+  v=$(cmake --version)
+  if [[ $v =~ "version 3" ]] ; then
+    cmake='cmake'
+  else
+    if rpm -q cmake3 ; then
+      cmake='cmake3'
+    elif [ $maj = "centos7" ] ; then
+      yum -y install epel-release cmake3
+      cmake='cmake3'
+    fi
+  fi
+
+  if ! rpm -q gcc-c++ ; then
+    yum -y install gcc-c++
+  fi
+
+  pkgs=(
+    ninja-build
+  )
+  for i in "${pkgs[@]}"; do
+    if ! rpm -q $i ; then
+      if [ $maj = 'centos7' ] ; then
+        yum install -y $i
+      else
+        dnf -y --enablerepo=PowerTools install $i
+      fi
+    fi
+  done
+elif [ -r /etc/issue ] ; then
+  maj=$(cat /etc/issue | awk '{print $1}')
+  v=$(cmake --version)
+  if [[ $v =~ "version 3" ]] ; then
+    cmake='cmake'
+  elif [ $maj = "Debian" ] ; then
+    if dpkg -l --no-pager cmake ; then
+      echo "Bad version of cmake..."
+      exit 1
+    else
+      if [ $my_id -eq 0 ] ; then
+        apt install -y cmake
+        cmake='cmake'
+      else
+        echo -e "cmake is not installed, you could enter, as root:\n\tapt install -y cmake\n\n"
+        exit 1
+      fi
+    fi
+    pkgs=(
+      gcc
+      ninja-build
+    )
+    for i in "${pkgs[@]}"; do
+      if ! dpkg -l --no-pager $i | grep "^ii" ; then
+        if [ $my_id -eq 0 ] ; then
+          apt install -y $i
+        else
+          echo -e "The package \"$i\" is not installed, you can install it, as root, with the command:\n\tapt install -y $i\n\n"
+          exit 1
+        fi
+      fi
+    done
+  else
+    echo "Bad version of cmake..."
+    exit 1
+  fi
+fi
+
 if [ ! -d build ] ; then
   mkdir build
 fi

--- a/cmake.sh
+++ b/cmake.sh
@@ -81,7 +81,7 @@ if [ ! -d build ] ; then
 fi
 
 cd build
-CXXFLAGS="-Wall -Wextra" cmake -DWITH_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -DWITH_PREFIX_LIB=/usr/lib64 -DWITH_TESTING=On $* ..
+CXXFLAGS="-Wall -Wextra" $cmake -DWITH_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -DWITH_PREFIX_LIB=/usr/lib64 -DWITH_TESTING=On $* ..
 
 #CXX=/usr/bin/clang++ CC=/usr/bin/clang CXXFLAGS="-Wall -Wextra" cmake -DWITH_PREFIX=/usr -DCMAKE_BUILD_TYPE=Debug -DWITH_PREFIX_LIB=/usr/lib64 -DWITH_TESTING=On $* ..
 


### PR DESCRIPTION
This patch just allows the use of the new C++ abi when available.
Also, the cmake.sh script is improved to work on Debian, Centos7 and Centos8.