### PR TITLE
fix(library): RTLD_NOW replaced by RTLD_LAZY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 20.10.2
+
+### Bugfixes
+
+*Libraries loading*
+
+A library is loaded lazily now. This allows not to check all link issues during
+the load.
+
 ## 20.10.1
 
 `February x, 2021`

--- a/src/library.cc
+++ b/src/library.cc
@@ -62,7 +62,7 @@ bool library::is_loaded() const noexcept {
 void library::load() {
   if (_handle)
     return;
-  if (!(_handle = dlopen(_filename.c_str(), RTLD_NOW | RTLD_GLOBAL)))
+  if (!(_handle = dlopen(_filename.c_str(), RTLD_LAZY | RTLD_GLOBAL)))
     throw basic_error() << "load library failed: " << dlerror();
 }
 


### PR DESCRIPTION
A little fix so that modules are loaded lazily now.