### PR TITLE
Mon 10885 log deadlock

### DIFF
--- a/inc/com/centreon/logging/backend.hh
+++ b/inc/com/centreon/logging/backend.hh
@@ -73,7 +73,7 @@ class backend {
   void _build_header(misc::stringifier& buffer);
 
   bool _is_sync;
-  mutable std::mutex _lock;
+  mutable std::recursive_mutex _lock;
   bool _show_pid;
   time_precision _show_timestamp;
   bool _show_thread_id;

--- a/src/logging/backend.cc
+++ b/src/logging/backend.cc
@@ -78,7 +78,7 @@ backend& backend::operator=(backend const& right) {
  *  @return True if synchronize, otherwise false.
  */
 bool backend::enable_sync() const {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   return (_is_sync);
 }
 
@@ -88,7 +88,7 @@ bool backend::enable_sync() const {
  *  @param[in] enable  True to synchronize backends data.
  */
 void backend::enable_sync(bool enable) {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   _is_sync = enable;
 }
 
@@ -109,7 +109,7 @@ void backend::log(uint64_t types, uint32_t verbose, char const* msg) noexcept {
  *  @return True if pid is display, otherwise false.
  */
 bool backend::show_pid() const {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   return (_show_pid);
 }
 
@@ -119,7 +119,7 @@ bool backend::show_pid() const {
  *  @param[in] enable  Enable or disable display pid.
  */
 void backend::show_pid(bool enable) {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   _show_pid = enable;
 }
 
@@ -129,7 +129,7 @@ void backend::show_pid(bool enable) {
  *  @return Time precision is display, otherwise none.
  */
 time_precision backend::show_timestamp() const {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   return (_show_timestamp);
 }
 
@@ -139,7 +139,7 @@ time_precision backend::show_timestamp() const {
  *  @param[in] enable  Enable or disable display timestamp.
  */
 void backend::show_timestamp(time_precision val) {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   _show_timestamp = val;
 }
 
@@ -149,7 +149,7 @@ void backend::show_timestamp(time_precision val) {
  *  @return True if thread id is display, otherwise false.
  */
 bool backend::show_thread_id() const {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   return (_show_thread_id);
 }
 
@@ -159,7 +159,7 @@ bool backend::show_thread_id() const {
  *  @param[in] enable  Enable or disable display thread id.
  */
 void backend::show_thread_id(bool enable) {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   _show_thread_id = enable;
 }
 
@@ -189,8 +189,8 @@ void backend::_build_header(misc::stringifier& buffer) {
  *  @param[in] right  The object to copy.
  */
 void backend::_internal_copy(backend const& right) {
-  std::lock_guard<std::mutex> lock1(_lock);
-  std::lock_guard<std::mutex> lock2(right._lock);
+  std::lock_guard<std::recursive_mutex> lock1(_lock);
+  std::lock_guard<std::recursive_mutex> lock2(right._lock);
   _is_sync = right._is_sync;
   _show_pid = right._show_pid;
   _show_timestamp = right._show_timestamp;

--- a/src/logging/file.cc
+++ b/src/logging/file.cc
@@ -79,7 +79,7 @@ file::~file() noexcept { close(); }
  *  Close file.
  */
 void file::close() noexcept {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
 
   if (!_out || _out == stdout || _out == stderr)
     return;
@@ -135,7 +135,7 @@ void file::log(uint64_t types,
     buffer.append(msg + last, i - last) << "\n";
   }
 
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   if (_out) {
     // Size control.
     if ((_max_size > 0) && (_size + buffer.size() > _max_size))
@@ -159,7 +159,7 @@ void file::log(uint64_t types,
  *  Open file.
  */
 void file::open() {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
 
   if (_out && _path.empty())
     return;
@@ -176,7 +176,7 @@ void file::open() {
  *  Close and open file.
  */
 void file::reopen() {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
 
   if (!_out || _out == stdout || _out == stderr)
     return;

--- a/src/logging/syslogger.cc
+++ b/src/logging/syslogger.cc
@@ -55,7 +55,7 @@ syslogger::~syslogger() noexcept { close(); }
  *  Close syslog.
  */
 void syslogger::close() noexcept {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   closelog();
 }
 
@@ -79,7 +79,7 @@ void syslogger::log(uint64_t types,
   misc::stringifier header;
   _build_header(header);
 
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   syslog(LOG_ERR, "%s%s", header.data(), msg);
 }
 
@@ -87,7 +87,7 @@ void syslogger::log(uint64_t types,
  *  Open syslog.
  */
 void syslogger::open() {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   openlog(_id.c_str(), 0, _facility);
 }
 
@@ -95,7 +95,7 @@ void syslogger::open() {
  *  Close and open syslog.
  */
 void syslogger::reopen() {
-  std::lock_guard<std::mutex> lock(_lock);
+  std::lock_guard<std::recursive_mutex> lock(_lock);
   closelog();
   openlog(_id.c_str(), 0, _facility);
 }

--- a/test/backend_test.hh
+++ b/test/backend_test.hh
@@ -1,5 +1,5 @@
 /*
-** Copyright 2011-2013 Centreon
+** Copyright 2011-2013, 2021 Centreon
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class backend_test : public backend {
            uint32_t verbose,
            char const* msg,
            uint32_t size) noexcept {
-    std::lock_guard<std::mutex> lock(_lock);
+    std::lock_guard<std::recursive_mutex> lock(_lock);
 
     (void)types;
     (void)verbose;


### PR DESCRIPTION
A mutex is replaced by a recursive_mutex in the logger system.
This should not stay since we will change the logger to use spdlog very soon (let's hope...)
