### PR TITLE
enh(ci) : New packaging workflow

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,12 +62,14 @@ try {
       node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/clib/${serie}/mon-clib-package.sh centos7"
+        archiveArtifacts artifacts: "output/x86_64/*.rpm"
       }
     },
     'packaging centos8': {
       node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/clib/${serie}/mon-clib-package.sh centos8"
+        archiveArtifacts artifacts: "output/x86_64/*.rpm"
       }
     },
     'packaging debian10': {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ if (env.BRANCH_NAME.startsWith('release-')) {
 ** Pipeline code.
 */
 stage('Source') {
-  node {
+  node("C++") {
     sh 'setup_centreon_build.sh'
     dir('centreon-clib') {
       checkout scm
@@ -46,7 +46,7 @@ stage('Source') {
 try {
   // sonarQube step to get qualityGate result
   stage('Quality gate') {
-    node {
+    node("C++") {
       def qualityGate = waitForQualityGate()
       if (qualityGate.status != 'OK') {
         currentBuild.result = 'FAIL'
@@ -59,25 +59,25 @@ try {
 
   stage('Package') {
     parallel 'packaging centos7': {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/clib/${serie}/mon-clib-package.sh centos7"
       }
     },
     'packaging centos8': {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/clib/${serie}/mon-clib-package.sh centos8"
       }
     },
     'packaging debian10': {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/clib/${serie}/mon-clib-package.sh debian10"
       }
     },
     'packaging debian10-armhf': {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/clib/${serie}/mon-clib-package.sh debian10-armhf"
       }
@@ -89,7 +89,7 @@ try {
 
   if ((env.BUILD == 'RELEASE') || (env.BUILD == 'QA')) {
     stage('Delivery') {
-      node {
+      node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/clib/${serie}/mon-clib-delivery.sh"
       }


### PR DESCRIPTION
## Description

Because of : 

- the new branch workflow
- the new packaging and rpm pushing workflow
- the necessity to give an easy access to rpm for the QA

Here's an enhancement that : 

- specify "QA" branches that are develop and dev-xx.yy.zz to manage the rpm pushing location 
- //lise build tests and packaging for all distributions
- push rpm directly on yum.centreon.com
It means that RPM created from develop and dev-xx.yy.zz branches are pushed directly to the unstable repo of yum.centreon.com and RPM created from release branches are pushed directly to the testing repo. 
No more RPM pushing for reference branches (for now) and PR- / CI branches

It speeds up the pipeline and the feedback loop for devs also.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Launch a job of each type of branches and check that everything is green on jenkins and that the packages are available on yum.centreon.com.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

