### PR TITLE
Add support to use with Ubuntu

### DIFF
--- a/cmake.sh
+++ b/cmake.sh
@@ -115,7 +115,7 @@ elif [ -r /etc/issue ] ; then
   v=$(cmake --version)
   if [[ $v =~ "version 3" ]] ; then
     cmake='cmake'
-  elif [ $maj = "Debian" ] ; then
+  elif [ $maj = "Debian" ] || [ $maj = "Ubuntu" ]; then
     if $dpkg -l cmake ; then
       echo "Bad version of cmake..."
       exit 1
@@ -145,7 +145,7 @@ elif [ -r /etc/issue ] ; then
     echo "Bad version of cmake..."
     exit 1
   fi
-  if [ $maj = "Debian" ] ; then
+  if [ $maj = "Debian" ] || [ $maj = "Ubuntu" ]; then
     pkgs=(
       gcc
       g++


### PR DESCRIPTION
Add support to use `cmake.sh` with Ubuntu.

Tested with Ubuntu 20.04 (LTS) and 21.04