### PR TITLE
fix(ci): unstash and clean rpms

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,14 +62,18 @@ try {
       node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/clib/${serie}/mon-clib-package.sh centos7"
+        stash name: 'el7-rpms', includes: "output/x86_64/*.rpm"
         archiveArtifacts artifacts: "output/x86_64/*.rpm"
+        sh 'rm -rf output' 
       }
     },
     'packaging centos8': {
       node("C++") {
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/clib/${serie}/mon-clib-package.sh centos8"
+        stash name: 'el8-rpms', includes: "output/x86_64/*.rpm"
         archiveArtifacts artifacts: "output/x86_64/*.rpm"
+        sh 'rm -rf output' 
       }
     },
     'packaging debian10': {
@@ -92,6 +96,8 @@ try {
   if ((env.BUILD == 'RELEASE') || (env.BUILD == 'QA')) {
     stage('Delivery') {
       node("C++") {
+        unstash 'el7-rpms'
+        unstash 'el8-rpms'
         sh 'setup_centreon_build.sh'
         sh "./centreon-build/jobs/clib/${serie}/mon-clib-delivery.sh"
       }


### PR DESCRIPTION
In order to have rpm delivered for develop and dev-xx-yy-zz jobs, we need to stash and unstash them at the delivery stage